### PR TITLE
Logout selects a logout endpoint from the IdP the session is part of

### DIFF
--- a/src/LightSaml/SpBundle/Exception/IdPZeroSingleLogoutEndpointsException.php
+++ b/src/LightSaml/SpBundle/Exception/IdPZeroSingleLogoutEndpointsException.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the LightSAML SP-Bundle package.
+ *
+ * (c) Milos Tomic <tmilos@lightsaml.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace LightSaml\SpBundle\Exception;
+
+class IdPZeroSingleLogoutEndpointsException extends \LogicException
+{
+
+}


### PR DESCRIPTION
This PR makes the logout functionality a bit more intelligent in that it uses the IDP of the session to select the endpoint that should be used to perform the logout against.

It is incomplete and should not be merged but I wanted to get feedback on how to correctly solve the outstanding issue. As it is, the SP can initiate a logout request, but it cannot process an IdP initiated logout. 

The reason for this is that I don't know which binding type to set in `LogoutMessageContextFactory::surroundWithContext`. When we're initiating the logout, we get the last session and in there is the IdP entityID, from there I can lookup the logout endpoint and get the binding type. We don't have this when the remote side is initiating the logout. 

We don't have an in-depth knowledge of the LightSaml library, is there an obvious way to do this?
