### PR TITLE
PPCDEV-6430 - Sign Logout SAML Messages by default

### DIFF
--- a/src/LightSaml/SpBundle/Model/Protocol/LogoutMessageContextFactory.php
+++ b/src/LightSaml/SpBundle/Model/Protocol/LogoutMessageContextFactory.php
@@ -12,6 +12,7 @@
 namespace LightSaml\SpBundle\Model\Protocol;
 
 use LightSaml\Context\Profile\MessageContext;
+use LightSaml\Credential\X509CredentialInterface;
 use LightSaml\Model\Assertion\Issuer;
 use LightSaml\Model\Assertion\NameID;
 use LightSaml\Model\Protocol\LogoutRequest;
@@ -22,7 +23,9 @@ use LightSaml\Model\Protocol\Status;
 use LightSaml\Model\Protocol\StatusCode;
 use LightSaml\SamlConstants;
 use LightSaml\State\Sso\SsoSessionState;
+use LightSaml\Store\Credential\CredentialStoreInterface;
 use LightSaml\Store\EntityDescriptor\EntityDescriptorStoreInterface;
+use LightSaml\Model\XmlDSig\SignatureWriter;
 
 /**
  * Class LogoutMessageFactory.
@@ -33,17 +36,24 @@ class LogoutMessageContextFactory
     private $spEntityId;
     /** @var EntityDescriptorStoreInterface */
     private $entityDescriptorStore;
+    /** @var CredentialStoreInterface */
+    private $ownCredentialStore;
 
     /**
      * LogoutMessageFactory constructor.
      *
-     * @param string                         $spEntityId
+     * @param string $spEntityId
      * @param EntityDescriptorStoreInterface $entityDescriptorStore
+     * @param CredentialStoreInterface $ownCredentialStore
      */
-    public function __construct($spEntityId, EntityDescriptorStoreInterface $entityDescriptorStore)
-    {
+    public function __construct(
+        $spEntityId,
+        EntityDescriptorStoreInterface $entityDescriptorStore,
+        CredentialStoreInterface $ownCredentialStore
+    ) {
         $this->spEntityId = $spEntityId;
         $this->entityDescriptorStore = $entityDescriptorStore;
+        $this->ownCredentialStore = $ownCredentialStore;
     }
 
     /**
@@ -94,7 +104,8 @@ class LogoutMessageContextFactory
         $samlMessage
             ->setID(LightSamlHelper::generateID())
             ->setIssueInstant(new \DateTime())
-            ->setIssuer(new Issuer($this->spEntityId));
+            ->setIssuer(new Issuer($this->spEntityId))
+            ->setSignature($this->getSignature());
     }
 
     /**
@@ -133,5 +144,15 @@ class LogoutMessageContextFactory
         $context->setBindingType($this->getSingleLogoutServiceBindingType());
 
         return $context;
+    }
+
+    /**
+     * @return SignatureWriter
+     */
+    private function getSignature()
+    {
+        /** @var X509CredentialInterface[] $ownCredential */
+        $ownCredential = $this->ownCredentialStore->getByEntityId($this->spEntityId);
+        return new SignatureWriter($ownCredential[0]->getCertificate(), $ownCredential[0]->getPrivateKey());
     }
 }

--- a/src/LightSaml/SpBundle/Model/Protocol/LogoutMessageContextFactory.php
+++ b/src/LightSaml/SpBundle/Model/Protocol/LogoutMessageContextFactory.php
@@ -21,6 +21,7 @@ use LightSaml\Helper as LightSamlHelper;
 use LightSaml\Model\Protocol\SamlMessage;
 use LightSaml\Model\Protocol\Status;
 use LightSaml\Model\Protocol\StatusCode;
+use LightSaml\Model\XmlDSig\Signature;
 use LightSaml\SamlConstants;
 use LightSaml\State\Sso\SsoSessionState;
 use LightSaml\Store\Credential\CredentialStoreInterface;
@@ -147,7 +148,7 @@ class LogoutMessageContextFactory
     }
 
     /**
-     * @return SignatureWriter
+     * @return Signature
      */
     private function getSignature()
     {

--- a/src/LightSaml/SpBundle/Resources/config/services.yml
+++ b/src/LightSaml/SpBundle/Resources/config/services.yml
@@ -16,6 +16,7 @@ services:
         arguments:
             - "%lightsaml.own.entity_id%"
             - "@lightsaml.party.idp_entity_descriptor_store"
+            - "@lightsaml.own.credential_store"
 
     http_client:
         class: Http\Adapter\Guzzle6\Client


### PR DESCRIPTION
Many Identity Providers using SingleLogout requires that e.g LogoutRequest is signed - since that change don't affect logout requests without verification it's safe to make it a default behavior.